### PR TITLE
Add link to home.mycroft.ai

### DIFF
--- a/market/frontend/v1/market-ui/src/app/header/header.component.html
+++ b/market/frontend/v1/market-ui/src/app/header/header.component.html
@@ -1,5 +1,7 @@
 <mat-toolbar>
-    <img src="../../assets/header-logo.svg">
+    <a href="https://home.mycroft.ai">
+        <img src="../../assets/header-logo.svg">
+    </a>
     <fa-icon class='separator' [icon]="separatorIcon"></fa-icon>
     <div class="mat-subheading-1" style="margin-bottom: 0">MARKETPLACE</div>
 


### PR DESCRIPTION
There was no way to navigate away from the marketplace.  Made the Mycroft logo clickable and navigate to home.mycroft.ai