### PR TITLE
Device preferences fixes 

### DIFF
--- a/api/account/account_api/endpoints/preferences.py
+++ b/api/account/account_api/endpoints/preferences.py
@@ -25,6 +25,7 @@ class PreferencesEndpoint(SeleneEndpoint):
     def __init__(self):
         super(PreferencesEndpoint, self).__init__()
         self.preferences = None
+        self.cache = self.config['SELENE_CACHE']
         self.etag_manager: ETagManager = ETagManager(self.cache, self.config)
 
     def get(self):


### PR DESCRIPTION
Expiring etags when the device preference is updated and making sure we are returning the correct system unit