### PR TITLE
Fixing skill manifest uploading.

### DIFF
--- a/shared/selene/data/skill/repository/sql/update_skill_manifest.sql
+++ b/shared/selene/data/skill/repository/sql/update_skill_manifest.sql
@@ -7,7 +7,7 @@ SET
     install_ts = %(installed)s,
     update_ts = %(updated)s
 WHERE
-    id = (
+    id IN (
         SELECT
             dev_skill.id
         FROM


### PR DESCRIPTION
There's a subquery used to update the device_skill table with the information from the skill manifest uploaded. Sometimes this subquery returns more than 1 result and that is breaking the API call