### PR TITLE
Fix typo in env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo -u postgres psql -c "CREATE ROLE selene WITH LOGIN ENCRYPTED PASSWORD '<pas
 * Add environment variables containing these passwords for the bootstrap script
 ```
 export DB_PASSWORD=<selene user password>
-export POSTGRES_PASWORD=<postgres user password>
+export POSTGRES_PASSWORD=<postgres user password>
 ```
 * Run the bootstrap script
 ```


### PR DESCRIPTION
## Description
Just fixing a typo I saw as I'm setting up selene for the first time

## How to test
<documentation only>
variable referenced:
bootstrap_mycroft_db.py:93:            db_password = environ.get('POSTGRES_PASSWORD')

## Contributor license agreement signed?
Signed!
