### PR TITLE
add execution of skill data collection script for 20.02

### DIFF
--- a/batch/job_scheduler/jobs.py
+++ b/batch/job_scheduler/jobs.py
@@ -115,6 +115,14 @@ def load_19_08_skills():
     job_runner.run_job()
 
 
+def load_20_02_skills():
+    """Load the json file from the mycroft-skills-data repository to the DB"""
+    job_runner = JobRunner('load_skill_display_data.py')
+    job_runner.job_args = '--core-version 20.02'
+    job_runner.job_date = date.today() - timedelta(days=1)
+    job_runner.run_job()
+
+
 def parse_core_metrics():
     """Copy rows from metric.core to de-normalized metric.core_interaction
 
@@ -156,6 +164,7 @@ schedule.every().day.at('00:05').do(update_device_last_contact)
 schedule.every().day.at('00:10').do(parse_core_metrics)
 schedule.every().day.at('00:15').do(load_19_02_skills)
 schedule.every().day.at('00:20').do(load_19_08_skills)
+schedule.every().day.at('00:25').do(load_20_02_skills)
 
 # Run the schedule
 while True:


### PR DESCRIPTION
## Description
The script that converts the data in the mycroft-skill-data repository takes a branch argument.  It was not being executed in production against the new(ish) 20.02 version.  Added job to the schedule for this version.

## How to test
Update job scheduler and check that 20.02 skills are added to database.

## Contributor license agreement signed?
CLA [yes]
