### PR TITLE
Add post processing to Jenkins to clean up Docker containers and images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                         --build-arg github_api_key=${GITHUB_API_PSW} \
                         --build-arg api_name=public \
                         --target api-code-check --no-cache \
-                        --label branch=${BRANCH_ALIAS} \
+                        --label job=${JOB_NAME} \
                         -t selene-linter:${BRANCH_ALIAS} .
                 """
                 labelledShell label: 'Public API Check', script: """
@@ -77,7 +77,7 @@ pipeline {
                     docker build \
                         --target db-bootstrap \
                         --build-arg github_api_key=${GITHUB_API_PSW} \
-                        --label branch=${BRANCH_ALIAS} \
+                        --label job=${JOB_NAME} \
                         -t selene-db:${BRANCH_ALIAS} .
                 """
                 timeout(time: 5, unit: 'MINUTES')
@@ -101,7 +101,7 @@ pipeline {
                     docker build \
                         --build-arg stripe_api_key=${STRIPE_KEY} \
                         --target account-api-test \
-                        --label branch=${BRANCH_ALIAS} \
+                        --label job=${JOB_NAME}} \
                         -t selene-account:${BRANCH_ALIAS} .
                 """
                 timeout(time: 5, unit: 'MINUTES')
@@ -110,7 +110,7 @@ pipeline {
                         docker run \
                             --net selene-net \
                             -v '${HOME}/allure/selene/:/root/allure' \
-                            --label branch={$BRANCH_ALIAS} \
+                            --label job=${JOB_NAME} \
                             selene-account:${BRANCH_ALIAS}
                     """
                 }
@@ -130,7 +130,7 @@ pipeline {
                         --build-arg github_client_id=${GITHUB_CLIENT_ID} \
                         --build-arg github_client_secret=${GITHUB_CLIENT_SECRET} \
                         --target sso-api-test \
-                        --label branch=${BRANCH_ALIAS} \
+                        --label job=${JOB_NAME} \
                         -t selene-sso:${BRANCH_ALIAS} .
                 """
                 timeout(time: 2, unit: 'MINUTES')
@@ -158,7 +158,7 @@ pipeline {
                         --build-arg google_stt_key=${GOOGLE_STT_KEY} \
                         --build-arg wolfram_alpha_key=${WOLFRAM_ALPHA_KEY} \
                         --target public-api-test \
-                        --label branch=${BRANCH_ALIAS} \
+                        --label job=${JOB_NAME} \
                         -t selene-public:${BRANCH_ALIAS} .
                 """
                 timeout(time: 2, unit: 'MINUTES')
@@ -190,7 +190,7 @@ pipeline {
             sh(
                 label: 'Delete Docker Image on Success',
                 script: '''
-                    docker image prune --all --force --filter label=branch=${BRANCH_ALIAS};
+                    docker image prune --all --force --filter label=job=${JOB_NAME};
                 '''
             )
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
                         --build-arg github_api_key=${GITHUB_API_PSW} \
                         --build-arg api_name=public \
                         --target api-code-check --no-cache \
+                        --label branch=${BRANCH_ALIAS} \
                         -t selene-linter:${BRANCH_ALIAS} .
                 """
                 labelledShell label: 'Public API Check', script: """
@@ -76,6 +77,7 @@ pipeline {
                     docker build \
                         --target db-bootstrap \
                         --build-arg github_api_key=${GITHUB_API_PSW} \
+                        --label branch=${BRANCH_ALIAS} \
                         -t selene-db:${BRANCH_ALIAS} .
                 """
                 timeout(time: 5, unit: 'MINUTES')
@@ -99,6 +101,7 @@ pipeline {
                     docker build \
                         --build-arg stripe_api_key=${STRIPE_KEY} \
                         --target account-api-test \
+                        --label branch=${BRANCH_ALIAS} \
                         -t selene-account:${BRANCH_ALIAS} .
                 """
                 timeout(time: 5, unit: 'MINUTES')
@@ -107,6 +110,7 @@ pipeline {
                         docker run \
                             --net selene-net \
                             -v '${HOME}/allure/selene/:/root/allure' \
+                            --label branch={$BRANCH_ALIAS} \
                             selene-account:${BRANCH_ALIAS}
                     """
                 }
@@ -126,6 +130,7 @@ pipeline {
                         --build-arg github_client_id=${GITHUB_CLIENT_ID} \
                         --build-arg github_client_secret=${GITHUB_CLIENT_SECRET} \
                         --target sso-api-test \
+                        --label branch=${BRANCH_ALIAS} \
                         -t selene-sso:${BRANCH_ALIAS} .
                 """
                 timeout(time: 2, unit: 'MINUTES')
@@ -153,6 +158,7 @@ pipeline {
                         --build-arg google_stt_key=${GOOGLE_STT_KEY} \
                         --build-arg wolfram_alpha_key=${WOLFRAM_ALPHA_KEY} \
                         --target public-api-test \
+                        --label branch=${BRANCH_ALIAS} \
                         -t selene-public:${BRANCH_ALIAS} .
                 """
                 timeout(time: 2, unit: 'MINUTES')
@@ -165,6 +171,28 @@ pipeline {
                     """
                 }
             }
+        }
+    }
+    post {
+        always {
+            sh(
+                label: 'Cleanup lingering docker containers and images.',
+                script: """
+                    docker container prune --force;
+                    docker image prune --force;
+                """
+            )
+        }
+        success {
+            // Docker images should remain upon failure for troubleshooting purposes.  However,
+            // if the stage is successful, there is no reason to look back at the Docker image.  In theory
+            // broken builds will eventually be fixed so this step should run eventually for every PR
+            sh(
+                label: 'Delete Docker Image on Success',
+                script: '''
+                    docker image prune --all --force --filter label=branch=${BRANCH_ALIAS};
+                '''
+            )
         }
     }
 }


### PR DESCRIPTION
## Description
Cleans up Docker images after the CI process completes successfully.  Images will remain if the CI process fails for troubleshooting purposes.  Assumption is that if the build is successful, the docker images will no longer be needed.

## How to test
This PR passes its CI requirement and there are no lingering images on the Docker host.

## Contributor license agreement signed?
CLA [Y]
