### PR TITLE
fix module reference

### DIFF
--- a/shared/selene/data/device/entity/default.py
+++ b/shared/selene/data/device/entity/default.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 
 from selene.data.geography import City, Country, Region, Timezone
 from .text_to_speech import TextToSpeech
-from data.wake_word.entity.wake_word import WakeWord
+from selene.data.wake_word.entity.wake_word import WakeWord
 
 
 @dataclass

--- a/shared/selene/data/device/entity/device.py
+++ b/shared/selene/data/device/entity/device.py
@@ -22,7 +22,7 @@ from datetime import datetime
 
 from selene.data.geography import City, Country, Region, Timezone
 from .text_to_speech import TextToSpeech
-from data.wake_word.entity.wake_word import WakeWord
+from selene.data.wake_word.entity.wake_word import WakeWord
 
 
 @dataclass

--- a/shared/selene/data/device/repository/default.py
+++ b/shared/selene/data/device/repository/default.py
@@ -20,7 +20,7 @@
 from selene.data.geography import City, Country, Region, Timezone
 from ..entity.default import AccountDefaults
 from ..entity.text_to_speech import TextToSpeech
-from data.wake_word.entity.wake_word import WakeWord
+from selene.data.wake_word.entity.wake_word import WakeWord
 from ...repository_base import RepositoryBase
 
 defaults_dataclasses = dict(


### PR DESCRIPTION
## Description
Behave tests in Jenkins failing with 
```

  File "/opt/selene/selene-backend/shared/selene/data/device/entity/device.py", line 25, in <module>

    from data.wake_word.entity.wake_word import WakeWord
```

This seems to be mis-referenced, but I can't see how that previously worked. 

## How to test
Behave tests