### PR TITLE
Change how the SSH key is passed to the API

### DIFF
--- a/api/account/account_api/api.py
+++ b/api/account/account_api/api.py
@@ -140,9 +140,7 @@ ssh_key_validation_endpoint = SshKeyValidatorEndpoint.as_view(
     "ssh_key_validation_endpoint"
 )
 acct.add_url_rule(
-    "/api/ssh-key/<string:ssh_key>",
-    view_func=ssh_key_validation_endpoint,
-    methods=["GET"],
+    "/api/ssh-key", view_func=ssh_key_validation_endpoint, methods=["GET"],
 )
 
 timezone_endpoint = TimezoneEndpoint.as_view("timezone_endpoint")

--- a/api/account/account_api/endpoints/ssh_key_validator.py
+++ b/api/account/account_api/endpoints/ssh_key_validator.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Endpoint to validate the contents of the SSH public key."""
-
+from urllib.parse import unquote_plus
 from http import HTTPStatus
 
 from selene.api import SeleneEndpoint
@@ -27,9 +27,14 @@ from selene.util.ssh import validate_rsa_public_key
 class SshKeyValidatorEndpoint(SeleneEndpoint):
     """Validate the contents of an SSH public key."""
 
-    def get(self, ssh_key):
-        """Handle and HTTP GET request."""
+    def get(self):
+        """Handle and HTTP GET request.
+
+        The SSH key is encoded in the UI because it can contain characters that are
+        reserved for URL delimiting.
+        """
         self._authenticate()
-        ssh_key_is_valid = validate_rsa_public_key(ssh_key)
+        decoded_ssh_key = unquote_plus(self.request.args["key"])
+        ssh_key_is_valid = validate_rsa_public_key(decoded_ssh_key)
 
         return dict(isValid=ssh_key_is_valid), HTTPStatus.OK

--- a/api/account/tests/features/pantacor_update.feature
+++ b/api/account/tests/features/pantacor_update.feature
@@ -19,10 +19,18 @@ Feature: Interact with the Pantacor API
     When the user selects to apply the update
     Then the request will be successful
 
-  Scenario: User enters invalid SSH key
+  Scenario: User enters a valid SSH key
     Given an account
     And the account is authenticated
     And a device using Pantacor for continuous delivery
     When the user enters a well formed RSA SSH key
     Then the request will be successful
     And the response indicates that the SSH key is properly formatted
+
+  Scenario: User enters an invalid SSH key
+    Given an account
+    And the account is authenticated
+    And a device using Pantacor for continuous delivery
+    When the user enters a malformed RSA SSH key
+    Then the request will be successful
+    And the response indicates that the SSH key is malformed

--- a/api/account/tests/features/steps/pantacor_update.py
+++ b/api/account/tests/features/steps/pantacor_update.py
@@ -66,7 +66,9 @@ def apply_software_update(context):
 @when("the user enters a malformed RSA SSH key")
 def validate_invalid_ssh_key(context):
     """Make an API call to check the validity of a RSA SSH key."""
-    response = context.client.get("/api/ssh-key/foo", content_type="application/json")
+    response = context.client.get(
+        "/api/ssh-key?key=foo", content_type="application/json"
+    )
     context.response = response
 
 
@@ -74,7 +76,7 @@ def validate_invalid_ssh_key(context):
 def validate_valid_ssh_key(context):
     """Make an API call to check the validity of a RSA SSH key."""
     response = context.client.get(
-        "/api/ssh-key/ssh-rsa%20AAAAB3NzaC1yc2EAAAADAQABAAACAQDEwmtmRho==%20foo",
+        "/api/ssh-key?key=ssh-rsa%20AAAAB3NzaC1yc2EAAAADAQABAAACAQDEwmtmRho==%20foo",
         content_type="application/json",
     )
     context.response = response


### PR DESCRIPTION
## Description
SSH keys can contain special characters reserved as URL delimiters.  Encoding the ssh key on the UI and decoding it the API fixes the issue.

## How to test
Paste a valid RSA SSH key into the device edit screen for a Mark II.  It should allow saving.

## Contributor license agreement signed?
CLA [Y] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
