### PR TITLE
No milliseconds in last activity timestamp

### DIFF
--- a/shared/selene/data/account/repository/account.py
+++ b/shared/selene/data/account/repository/account.py
@@ -152,8 +152,13 @@ class AccountRepository(RepositoryBase):
                     **result["account"]["membership"]
                 )
             if result["account"]["last_activity"] is not None:
+                no_milliseconds = len(result["account"]["last_activity"]) == 19
+                if no_milliseconds:
+                    parse_string = "%Y-%m-%dT%H:%M:%S"
+                else:
+                    parse_string = "%Y-%m-%dT%H:%M:%S.%f"
                 result["account"]["last_activity"] = datetime.strptime(
-                    result["account"]["last_activity"], "%Y-%m-%dT%H:%M:%S.%f"
+                    result["account"]["last_activity"], parse_string
                 )
             account = Account(**result["account"])
 


### PR DESCRIPTION
## Description
Fixes an obscure bug where the last activity timestamp fails to be converted to a datetime object because there are no milliseconds.

## How to test
Call an API endpoint that requires authentication with an account that has no milliseconds in its last activity timestamp.

## Contributor license agreement signed?
CLA [Y] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
