### PR TITLE
Fixed and issue with the sending email on a support ticket.

### DIFF
--- a/api/public/public_api/endpoints/device_email.py
+++ b/api/public/public_api/endpoints/device_email.py
@@ -56,7 +56,7 @@ class DeviceEmailEndpoint(PublicEndpoint):
         """Send an email to the account that owns the device that requested it."""
         message = EmailMessage(
             recipient=account.email_address,
-            sender=self.request.json["sender"],
+            sender="reports@mycroft.ai",
             subject=self.request.json["title"],
             body=self.request.json["body"],
         )

--- a/api/public/public_api/endpoints/device_email.py
+++ b/api/public/public_api/endpoints/device_email.py
@@ -56,7 +56,7 @@ class DeviceEmailEndpoint(PublicEndpoint):
         """Send an email to the account that owns the device that requested it."""
         message = EmailMessage(
             recipient=account.email_address,
-            sender="reports@mycroft.ai",
+            sender="support@mycroft.ai",
             subject=self.request.json["title"],
             body=self.request.json["body"],
         )


### PR DESCRIPTION
## Description
The Device API endpoint that attempted to send an email was returning an internal server error.  This was due to the "sender" from the API request not being a valid email address. 

## How to test
Run the support skill on the device and the email will send.

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
