### PR TITLE
Add Wolfram Alpha Simple API endpoint

### DIFF
--- a/api/public/public_api/api.py
+++ b/api/public/public_api/api.py
@@ -48,6 +48,7 @@ from .endpoints.premium_voice import PremiumVoiceEndpoint
 from .endpoints.stripe_webhook import StripeWebHookEndpoint
 from .endpoints.wake_word_file import WakeWordFileUpload
 from .endpoints.wolfram_alpha import WolframAlphaEndpoint
+from .endpoints.wolfram_alpha_simple import WolframAlphaSimpleEndpoint
 from .endpoints.wolfram_alpha_spoken import WolframAlphaSpokenEndpoint
 
 _log = configure_logger("public_api")
@@ -134,6 +135,11 @@ public.add_url_rule(
 public.add_url_rule(
     "/v1/auth/token",
     view_func=DeviceRefreshTokenEndpoint.as_view("refresh_token_api"),
+    methods=["GET"],
+)
+public.add_url_rule(
+    "/v1/wolframAlphaSimple",
+    view_func=WolframAlphaSimpleEndpoint.as_view("wolfram_alpha_simple_api"),
     methods=["GET"],
 )
 public.add_url_rule(

--- a/api/public/public_api/endpoints/wolfram_alpha_simple.py
+++ b/api/public/public_api/endpoints/wolfram_alpha_simple.py
@@ -1,5 +1,5 @@
 # Mycroft Server - Backend
-# Copyright (C) 2019 Mycroft AI Inc
+# Copyright (C) 2021 Mycroft AI Inc
 # SPDX-License-Identifier: 	AGPL-3.0-or-later
 #
 # This file is part of the Mycroft Server.

--- a/api/public/public_api/endpoints/wolfram_alpha_simple.py
+++ b/api/public/public_api/endpoints/wolfram_alpha_simple.py
@@ -1,0 +1,47 @@
+# Mycroft Server - Backend
+# Copyright (C) 2019 Mycroft AI Inc
+# SPDX-License-Identifier: 	AGPL-3.0-or-later
+#
+# This file is part of the Mycroft Server.
+#
+# The Mycroft Server is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import os
+from http import HTTPStatus
+
+import requests
+
+from selene.api import PublicEndpoint
+
+
+class WolframAlphaSimpleEndpoint(PublicEndpoint):
+    """Endpoint to communicate with the Wolfram Alpha Simple API.
+
+    The Simple API returns a universally viewable image format.
+    https://products.wolframalpha.com/simple-api/
+    """
+
+    def __init__(self):
+        super(WolframAlphaSimpleEndpoint, self).__init__()
+        self.wolfram_alpha_key = os.environ['WOLFRAM_ALPHA_KEY']
+        self.wolfram_alpha_url = os.environ['WOLFRAM_ALPHA_URL']
+
+    def get(self):
+        self._authenticate()
+        params = dict(self.request.args)
+        params['appid'] = self.wolfram_alpha_key
+        response = requests.get(self.wolfram_alpha_url + '/v1/simple', params=params)
+        code = response.status_code
+        response = (response.text, code) if code == HTTPStatus.OK else ('', code)
+        return response

--- a/api/public/tests/features/steps/wolfram_alpha.py
+++ b/api/public/tests/features/steps/wolfram_alpha.py
@@ -33,6 +33,16 @@ def send_question(context):
     )
 
 
+@when("a question is sent to the wolfram alpha simple endpoint")
+def send_question(context):
+    login = context.device_login
+    access_token = login["accessToken"]
+    context.wolfram_response = context.client.get(
+        "/v1/wolframAlphaSimple?i=What+airplanes+are+flying+overhead%3F&background=F5F5F5&foreground=white&fontsize=16&width=400&units=Metric",
+        headers=dict(Authorization="Bearer {token}".format(token=access_token)),
+    )
+
+
 @when("a question is sent to the wolfram alpha spoken endpoint")
 def send_question(context):
     login = context.device_login

--- a/api/public/tests/features/wolfram_alpha.feature
+++ b/api/public/tests/features/wolfram_alpha.feature
@@ -11,6 +11,11 @@ Feature: Integration with Wolfram Alpha API
     And the account's last activity time is updated
     And the account activity metrics will be updated
 
+  Scenario: Question sent to the wolfram alpha simple endpoint
+    When a question is sent to the wolfram alpha simple endpoint
+    Then the answer provided by Wolfram Alpha is returned
+    And the device's last contact time is updated
+
   Scenario: Question sent to the wolfram alpha spoken endpoint
     When a question is sent to the wolfram alpha spoken endpoint
     Then the answer provided by Wolfram Alpha is returned


### PR DESCRIPTION
## Description
Adds a new endpoint for the [Wolfram Alpha Simple API](https://products.wolframalpha.com/simple-api/documentation/).

This API is useful for fetching images related to Wolfram search results.

## How to test
Behave test added though I haven't yet tested this change.

## Contributor license agreement signed?
- [x] CLA
