### PR TITLE
New Wolfram Alpha v2 endpoint

### DIFF
--- a/api/public/public_api/api.py
+++ b/api/public/public_api/api.py
@@ -49,6 +49,7 @@ from .endpoints.stripe_webhook import StripeWebHookEndpoint
 from .endpoints.wake_word_file import WakeWordFileUpload
 from .endpoints.wolfram_alpha import WolframAlphaEndpoint
 from .endpoints.wolfram_alpha_spoken import WolframAlphaSpokenEndpoint
+from .endpoints.wolfram_alpha_v2 import WolframAlphaV2Endpoint
 
 _log = configure_logger("public_api")
 
@@ -139,6 +140,11 @@ public.add_url_rule(
 public.add_url_rule(
     "/v1/wolframAlphaSpoken",
     view_func=WolframAlphaSpokenEndpoint.as_view("wolfram_alpha_spoken_api"),
+    methods=["GET"],
+)
+public.add_url_rule(
+    "/v1/wolframAlphaFull",
+    view_func=WolframAlphaV2Endpoint.as_view("wolfram_alpha_v2_api"),
     methods=["GET"],
 )
 public.add_url_rule(

--- a/api/public/tests/features/steps/wolfram_alpha.py
+++ b/api/public/tests/features/steps/wolfram_alpha.py
@@ -23,12 +23,12 @@ from behave import when, then
 from hamcrest import assert_that
 
 
-@when("a query is sent to the Wolfram Alpha fallback")
+@when("a question is sent to the Wolfram Alpha full results endpoint")
 def send_question(context):
     login = context.device_login
     access_token = login["accessToken"]
     context.wolfram_response = context.client.get(
-        "/v1/wa?input=what+is+the+capital+of+Brazil",
+        "/v1/wolframAlphaFull?input=what+is+the+capital+of+Brazil",
         headers=dict(Authorization="Bearer {token}".format(token=access_token)),
     )
 

--- a/api/public/tests/features/wolfram_alpha.feature
+++ b/api/public/tests/features/wolfram_alpha.feature
@@ -5,7 +5,7 @@ Feature: Integration with Wolfram Alpha API
   requests.
 
   Scenario: Mycroft Core fallback system sends query to the Wolfram Alpha
-    When a query is sent to the Wolfram Alpha fallback
+    When a question is sent to the Wolfram Alpha full results endpoint
     Then the answer provided by Wolfram Alpha is returned
     And the device's last contact time is updated
     And the account's last activity time is updated


### PR DESCRIPTION
## Description
This adds a new endpoint for Wolfram Alpha's Full Results v2 API. 

It replaces and deprecates the existing 'wa' endpoint which was restricted to only pass on the input parameter and only return data in XML format.

The new endpoint allows the Skill developer to use any of the parameters supported by the Wolfram endpoint.

## How to test
Behave test updated to point to new endpoint.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
