### PR TITLE
Fix client encoding for PG connection

### DIFF
--- a/db/scripts/bootstrap_mycroft_db.py
+++ b/db/scripts/bootstrap_mycroft_db.py
@@ -108,6 +108,7 @@ class PostgresDB(object):
             sslmode=db_ssl_mode,
         )
         self.db.autocommit = True
+        self.db.set_client_encoding('UTF8')
 
     def close_db(self):
         self.db.close()


### PR DESCRIPTION
Set the encoding to utf8 so that it will correctly handle accented characters in the geography data.

This fixes #275 

## How to test
Bootstrap script no longer fails on accented characters

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)

I have signed the CLA previously
